### PR TITLE
条件判断表达式运算时结果不符合预期

### DIFF
--- a/OCRunner/RunEnv/MFValue.h
+++ b/OCRunner/RunEnv/MFValue.h
@@ -136,7 +136,7 @@ break;\
 #define UnaryExecute(resultName,operator,value)\
 do{\
     if (value.isPointer) {\
-        resultName = operator (value.pointer);\
+        resultName = operator (*(void **)value.pointer);\
         break;\
     }\
     UnaryExecuteBaseType(resultName,operator,value)\

--- a/OCRunnerTests/OCRunnerTests.swift
+++ b/OCRunnerTests/OCRunnerTests.swift
@@ -1144,4 +1144,22 @@ class CRunnerTests: XCTestCase {
         let result = scope.getValueWithIdentifier("result")?.objectValue
         XCTAssert(result as? NSNumber == NSNumber(value: 7), "\(result)");
     }
+    func testConditionNullCheck(){
+        let source =
+        """
+        id a = nil;
+        int b = 0;
+        if ([a description]) {
+            b = 1;
+        }else{
+            b = 2;
+        }
+        """
+        let ast = ocparser.parseSource(source)
+        for classValue in ast.nodes {
+            (classValue as! OCExecute).execute(scope);
+        }
+        let result = scope.getValueWithIdentifier("b")?.intValue
+        XCTAssert(result == 2, "\(result)");
+    }
 }


### PR DESCRIPTION
    NSArray *pictureList = nil;
    if (pictureList.count) {
        NSLog(@"1.错误：条件成立了");
    }else{
        NSLog(@"1.正确：条件不成立");
    }
    if (nil.count) {
        NSLog(@"2.错误：条件成立了");
    }else{
        NSLog(@"2.正确：条件不成立");
    }
    
    输出结果：
    1.错误：条件成立了
    2.错误：条件成立了