### PR TITLE
属性名长度为1的时候，拼接set方法的时候出错

### DIFF
--- a/OCRunner/RunnerClasses+Execute.m
+++ b/OCRunner/RunnerClasses+Execute.m
@@ -108,7 +108,7 @@ static void replace_getter_method(Class clazz, ORPropertyDeclare *prop){
 static void replace_setter_method(Class clazz, ORPropertyDeclare *prop){
     NSString *name = prop.var.var.varname;
     NSString *str1 = [[name substringWithRange:NSMakeRange(0, 1)] uppercaseString];
-    NSString *str2 = name.length > 1 ? [name substringFromIndex:1] : nil;
+    NSString *str2 = name.length > 1 ? [name substringFromIndex:1] : @"";
     SEL setterSEL = NSSelectorFromString([NSString stringWithFormat:@"set%@%@:",str1,str2]);
     const char *prtTypeEncoding  = prop.var.typeEncode;
     const char * typeEncoding = mf_str_append("v@:", prtTypeEncoding);

--- a/OCRunner/RunnerClasses+Recover.m
+++ b/OCRunner/RunnerClasses+Recover.m
@@ -64,7 +64,7 @@ void recover_method(BOOL isClassMethod, Class clazz, SEL sel){
     for (ORPropertyDeclare *prop in self.properties){
         NSString *name = prop.var.var.varname;
         NSString *str1 = [[name substringWithRange:NSMakeRange(0, 1)] uppercaseString];
-        NSString *str2 = name.length > 1 ? [name substringFromIndex:1] : nil;
+        NSString *str2 = name.length > 1 ? [name substringFromIndex:1] : @"";
         SEL getterSEL = NSSelectorFromString(name);
         SEL setterSEL = NSSelectorFromString([NSString stringWithFormat:@"set%@%@:",str1,str2]);
         recover_method(NO, class, getterSEL);


### PR DESCRIPTION
拼接属性的set方法的时候错误，导致调用的时候找不到set方法，代码如下：
![截屏2023-05-23 11 18 08](https://github.com/SilverFruity/OCRunner/assets/11827129/f3e0365d-ead5-4013-a9dc-0e478e6bb187)

拼接的时候debug如下：
![截屏2023-05-23 11 17 18](https://github.com/SilverFruity/OCRunner/assets/11827129/8918263a-0d56-4631-94e3-7dac885f8f5b)
